### PR TITLE
Only cast pandas Series or DataFrame to numpy if dtype is not 'O'.

### DIFF
--- a/pymc/PyMCObjects.py
+++ b/pymc/PyMCObjects.py
@@ -305,7 +305,7 @@ class Potential(PotentialBase):
                 parameter] = lazy_logp_partial_gradients
 
     def get_logp(self):
-        
+
         if self.verbose > 1:
             print_('\t' + self.__name__ + ': log-probability accessed.')
         logp = self._logp.get()
@@ -736,9 +736,9 @@ class Stochastic(StochasticBase):
 
         # Initialize value, either from value provided or from random function.
         try:
-            # Convert Pandas DataFrames and Series to numpy arrays
-            value = getattr(value, 'values', value)
             if dtype.kind != 'O' and value is not None:
+                # Convert Pandas DataFrames and Series to numpy arrays
+                value = getattr(value, 'values', value)
                 self._value = np.array(value, dtype=dtype)
                 self._value.flags['W'] = False
             else:

--- a/pymc/distributions.py
+++ b/pymc/distributions.py
@@ -797,7 +797,7 @@ def bernoulli_like(x, p):
       - :math:`Var(x)= p(1-p)`
 
     """
-    
+
     return flib.bernoulli(x, p)
 
 bernoulli_grad_like = {'p': flib.bern_grad_p}
@@ -2976,8 +2976,6 @@ def valuewrapper(f, arguments=None):
     """
     def wrapper(**kwds):
         value = kwds.pop('value')
-        # Handle Pandas DataFrames
-        value = getattr(value, 'values', value)
         return f(value, **kwds)
 
     if arguments is None:


### PR DESCRIPTION
'O' has before been a pass-through dtype that allowed users to pass in values that were not strictly numpy arrays. HDDM for example passed in pandas DataFrames which it then expected in the likelihood. With commit 7c7be9a52581bc666411fbc42420e997d71e34cc HDDM broke. With these changes, it works again.
