### PR TITLE
Deprecation of direct instantiation of Model objects.

### DIFF
--- a/pymc/MCMC.py
+++ b/pymc/MCMC.py
@@ -4,7 +4,7 @@ Class MCMC, which fits probability models using Markov Chain Monte Carlo, is def
 
 __all__ = ['MCMC']
 
-from .Model import Sampler
+from .Model import Sampler, Model
 from .StepMethods import StepMethodRegistry, assign_method, DrawFromPrior
 from .distributions import absolute_loss, squared_loss, chi_square_loss
 import sys
@@ -12,6 +12,7 @@ import time
 import pdb
 import numpy as np
 from .utils import crawl_dataless
+import warnings
 
 from .six import print_
 
@@ -71,6 +72,13 @@ class MCMC(Sampler):
           - **kwds :
               Keywords arguments to be passed to the database instantiation method.
         """
+        
+        if isinstance(input, Model):
+            message = 'Instantiating a Model object directly is deprecated. '
+            message += 'We recommend passing variables directly to the Model subclass.'
+            warnings.warn(message)
+            input = input.variables
+        
         Sampler.__init__(
             self,
             input,

--- a/pymc/MCMC.py
+++ b/pymc/MCMC.py
@@ -34,7 +34,6 @@ class MCMC(Sampler):
       :Parameters:
         - input : module, list, tuple, dictionary, set, object or nothing.
             Model definition, in terms of Stochastics, Deterministics, Potentials and Containers.
-            If nothing, all nodes are collected from the base namespace.
         - db : string
             The name of the database backend that will store the values
             of the stochastics and deterministics sampled during the MCMC loop.
@@ -57,14 +56,13 @@ class MCMC(Sampler):
     :SeeAlso: Model, Sampler, StepMethod.
     """
 
-    def __init__(self, input=None, db='ram',
+    def __init__(self, input=[], db='ram',
                  name='MCMC', calc_deviance=True, **kwds):
         """Initialize an MCMC instance.
 
         :Parameters:
           - input : module, list, tuple, dictionary, set, object or nothing.
               Model definition, in terms of Stochastics, Deterministics, Potentials and Containers.
-              If nothing, all nodes are collected from the base namespace.
           - db : string
               The name of the database backend that will store the values
               of the stochastics and deterministics sampled during the MCMC loop.

--- a/pymc/Model.py
+++ b/pymc/Model.py
@@ -78,24 +78,15 @@ class Model(ObjectContainer):
     :SeeAlso: Sampler, MAP, NormalApproximation, weight, Container, graph.
     """
 
-    def __init__(self, input=None, name=None, verbose=-1):
+    def __init__(self, input=[], name=None, verbose=-1):
         """Initialize a Model instance.
 
         :Parameters:
-          - input : module, list, tuple, dictionary, set, object or nothing.
+          - input : module, list, tuple, dictionary, set, or object.
               Model definition, in terms of Stochastics, Deterministics, Potentials and Containers.
-              If nothing, all nodes are collected from the base namespace.
         """
 
         # Get stochastics, deterministics, etc.
-        if input is None:
-            import warnings
-            warnings.warn(
-                'The MCMC() syntax is deprecated. Please pass in nodes explicitly via M = MCMC(input).')
-            import __main__
-            __main__.__dict__.update(self.__class__.__dict__)
-            input = __main__
-
         ObjectContainer.__init__(self, input)
 
         if name is not None:
@@ -173,14 +164,13 @@ class Sampler(Model):
     :SeeAlso: Model, MCMC.
     """
 
-    def __init__(self, input=None, db='ram', name='Sampler',
+    def __init__(self, input=[], db='ram', name='Sampler',
                  reinit_model=True, calc_deviance=False, verbose=0, **kwds):
         """Initialize a Sampler instance.
 
         :Parameters:
           - input : module, list, tuple, dictionary, set, object or nothing.
               Model definition, in terms of Stochastics, Deterministics, Potentials and Containers.
-              If nothing, all nodes are collected from the base namespace.
           - db : string
               The name of the database backend that will store the values
               of the stochastics and deterministics sampled during the MCMC loop.

--- a/pymc/NormalApproximation.py
+++ b/pymc/NormalApproximation.py
@@ -155,7 +155,7 @@ class MAP(Model):
     :SeeAlso: Model, EM, Sampler, scipy.optimize
     """
 
-    def __init__(self, input=None, eps=.001, diff_order=5, verbose=-1):
+    def __init__(self, input=[], eps=.001, diff_order=5, verbose=-1):
         if not scipy_imported:
             raise ImportError(
                 'Scipy must be installed to use NormApprox and MAP.')
@@ -562,7 +562,7 @@ class NormApprox(MAP, Sampler):
     :SeeAlso: Model, EM, Sampler, scipy.optimize
     """
 
-    def __init__(self, input=None, db='ram', eps=.001, diff_order=5, **kwds):
+    def __init__(self, input=[], db='ram', eps=.001, diff_order=5, **kwds):
         if not scipy_imported:
             raise ImportError(
                 'Scipy must be installed to use NormApprox and MAP.')


### PR DESCRIPTION
Passing a `Model` object to `MCMC` now strips out the variables in `__init__`. Default `input` is now an empty list rather than `None`.

Fixes #80 
