### PR TITLE
Remove conda from TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,25 @@
 language: python
 
-python:
-  - "2.7"
-  - "3.4"
-  
+matrix:
+  include:
+    - python: 2.7
+      env:
+        - NUMPYSPEC="--upgrade git+git://github.com/numpy/numpy.git@v1.10.2"
+    - python: 3.4
+      env:
+        - NUMPYSPEC="numpy" 
+addons:
+  apt:
+    packages:
+    - libatlas-dev
+    - libatlas-base-dev
+    - liblapack-dev
+    - gfortran
 before_install:
-  - sudo apt-get update
-  - sudo apt-get install liblapack-dev gfortran libblas-dev
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sudo ln -Tsf /{run,dev}/shm
-  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then wget http://repo.continuum.io/miniconda/Miniconda-3.6.0-Linux-x86_64.sh -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-3.6.0-Linux-x86_64.sh -O miniconda.sh; fi
-  - chmod +x miniconda.sh
-  - ./miniconda.sh -b
-  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then export PATH=/home/travis/miniconda/bin:$PATH; else export PATH=/home/travis/miniconda3/bin:$PATH; fi
-  
+  - travis_retry pip install --install-option="--no-cython-compile" Cython==0.22
+  - travis_retry pip install $NUMPYSPEC
+  - travis_retry pip install ipython pyzmq scipy nose matplotlib pandas
 install:
-  - conda create -n testenv --yes pip python=$TRAVIS_PYTHON_VERSION
-  - source activate testenv
-  - conda install --yes ipython pyzmq numpy scipy nose matplotlib pandas Cython 
   - python setup.py build_ext --inplace
 script:
   - nosetests -s pymc/tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ addons:
     - liblapack-dev
     - gfortran
 before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
   - travis_retry pip install --install-option="--no-cython-compile" Cython==0.22
   - travis_retry pip install $NUMPYSPEC
   - travis_retry pip install ipython pyzmq scipy nose matplotlib pandas

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,7 @@ language: python
 matrix:
   include:
     - python: 2.7
-      env:
-        - NUMPYSPEC="--upgrade git+git://github.com/numpy/numpy.git@v1.10.2"
     - python: 3.4
-      env:
-        - NUMPYSPEC="numpy" 
 addons:
   apt:
     packages:
@@ -19,8 +15,7 @@ before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - travis_retry pip install --install-option="--no-cython-compile" Cython==0.22
-  - travis_retry pip install $NUMPYSPEC
-  - travis_retry pip install ipython pyzmq scipy nose matplotlib pandas
+  - travis_retry pip install numpy ipython pyzmq scipy nose matplotlib pandas
 install:
   - python setup.py build_ext --inplace
 script:


### PR DESCRIPTION
This fixes gfortran incompatibility with conda binaries -- by not using anaconda.
