### PR TITLE
Fix typo in MCMC.tune causing NameError exc

### DIFF
--- a/pymc/MCMC.py
+++ b/pymc/MCMC.py
@@ -365,8 +365,10 @@ class MCMC(Sampler):
             tuning_count += step_method.tune(verbose=self.verbose)
             if verbose > 1:
                 print_(
-                    '\t\tTuning step method %s, returned %i\n' %i
-                    (step_method._id, tuning_count))
+                    '\t\tTuning step method %s, returned %i\n' % (
+                        step_method._id, tuning_count
+                    )
+                )
                 sys.stdout.flush()
 
         if self._burn_till_tuned:


### PR DESCRIPTION
Choosing `verbose=2` causes a NameError exception thrown when starting the sampling. Example code (using `sample` - the same for `isample`):

```
...
>>> M = Model(locals())
>>> M = MCMC(model)
>>> M.sample(10000, verbose=2)

Burn-in interval complete
    Tuning at iteration 1000
    Metropolis_beta tuning:
        value: 0.000410808077072
        acceptance rate: 0.002
        adaptive scale factor: 0.5

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "~/dev_env/local/lib/python2.7/site-packages/pymc/MCMC.py", line 279, in sample
    Sampler.sample(self, iter, length, verbose)
  File "~/dev_env/local/lib/python2.7/site-packages/pymc/Model.py", line 251, in sample
    self._loop()
  File "~/dev_env/local/lib/python2.7/site-packages/pymc/MCMC.py", line 294, in _loop
    self.tune()
  File "~/dev_env/local/lib/python2.7/site-packages/pymc/MCMC.py", line 361, in tune
    '\t\tTuning step method %s, returned %i\n' %i
NameError: global name 'i' is not defined
```

Commit: 5ead13787b948a179ac7e2ca26d48da57fecba10
Commit message:
When `verbose>1`, `sample` and `isample` raise
    `NameError: global name 'i' is not defined`
Caused by a `print_(..%s..%i) %i(str_, int_)`. Deleting `i` fixes it.
