### PR TITLE
Changed geometric to use 64-bit integers

### DIFF
--- a/pymc/flib.f
+++ b/pymc/flib.f
@@ -3140,7 +3140,7 @@ cf2py threadsafe
 
       IMPLICIT NONE
       INTEGER n,np,i
-      INTEGER x(n)
+      INTEGER*8 x(n)
       DOUBLE PRECISION p(np), p_tmp
       DOUBLE PRECISION like
       DOUBLE PRECISION infinity


### PR DESCRIPTION
Avoids overflow for large values.

Closes #120 
