### PR TITLE
Don't filter out parameters named 'args' or 'kwd' in utils.get_signature().

### DIFF
--- a/pymc/utils.py
+++ b/pymc/utils.py
@@ -45,9 +45,8 @@ symmetrize = flib.symmetrize
 PY3 = sys.version_info >= (3, 3)
 
 def get_signature_py3(func):
-    sig = inspect.signature(func)
-    defaults = tuple(p.default for p in sig.parameters.values() if p.default is not inspect._empty)
-    args = [k for k in sig.parameters.keys() if k not in ('args', 'kwds')]
+    (args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults,
+        annotations) = inspect.getfullargspec(func)
     return args, defaults
     
 def get_signature_py2(func):


### PR DESCRIPTION
Fixes #172.

Uses [inspect.getfullargspec](https://docs.python.org/3/library/inspect.html#inspect.getfullargspec) instead of `inspect.signature`. This makes it closer to the python 2 version of the same function, and hopefully more maintainable.

`inspect.getfullargspec` had previously been deprecated in favor of `inspect.signature`, but that deprecation has been reversed in order to maintain better compatibility with Python 2/3 codebases.