### PR TITLE
await is a keyword in Python 3.7. Rename to await_lock.

### DIFF
--- a/pymc/threadpool.py
+++ b/pymc/threadpool.py
@@ -343,7 +343,7 @@ class CountDownLatch(object):
             self.main_lock.release()
         self.counter_lock.release()
 
-    def await(self):
+    def await_lock(self):
         self.main_lock.acquire()
         self.main_lock.release()
 
@@ -384,7 +384,7 @@ def map_noreturn(targ, argslist):
                         exc_callback=eb,
                         args=args,
                         requestID=id(args)))
-    done_lock.await()
+    done_lock.await_lock()
 
     if exceptions:
         six.reraise(*exceptions[0])


### PR DESCRIPTION
```
  File "/home/nachomcapella/anaconda3/lib/python3.7/site-packages/pymc/__init__.py", line 19, in <module>
    from .threadpool import *
  File "/home/nachomcapella/anaconda3/lib/python3.7/site-packages/pymc/threadpool.py", line 346
    def await(self):
            ^
SyntaxError: invalid syntax
```