### PR TITLE
Point to PyMC3 in the docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,8 @@
 PyMC User's Guide
 =================
 
+**CAUTION**: This is the **old** PyMC project. Please **use PyMC3 instead**: `<https://docs.pymc.io/>`_
+
 Contents:
 
 .. toctree::


### PR DESCRIPTION
Hi, 

Thanks so much for your great work! 

This change here is to point visitors of https://pymc-devs.github.io/pymc/ to your new homepage, since it is not obvious now on that page that PyMC3 exists and there are links to your old page on places [outside of your project](https://github.com/scipy-lectures/scipy-lecture-notes/pull/492/files).